### PR TITLE
Call `_flush` instead of `end`

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -45,12 +45,12 @@ class SortAndDedupe extends stream.Transform {
         next();
     }
 
-    end () {
+    _flush (next) {
         Array
             .from(this.rows.values())
             .sort(compareId)
             .forEach(row => this.push(row));
-        this.push(null);
+        next();
     }
 }
 


### PR DESCRIPTION
We need a failing test as well. All current tests pass, though.

Docs: https://nodejs.org/api/stream.html#stream_transform_flush_callback