### PR TITLE
fix: add missing support for multiple entrypoints in same feed

### DIFF
--- a/lib/feed-entrypoints.js
+++ b/lib/feed-entrypoints.js
@@ -7,7 +7,5 @@
  * @returns {object} - First entry in feed with property entry: true
  */
 module.exports = function feedEntrypoint(feed) {
-    for (const item of feed) {
-        if (item.entry) return item;
-    }
+    return feed.filter(item => Boolean(item.entry));
 };

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const feedEntrypoint = require('./feed-entrypoint');
+const feedEntrypoints = require('./feed-entrypoints');
 const unpackFeed = require('./unpack-feed');
 const { join } = require('path');
 const browserify = require('browserify');
@@ -39,8 +39,10 @@ module.exports = async (feeds, options) => {
     await Promise.all(
         feeds.map(async feed => {
             const root = join(opts.directory, await hashFeed(feed));
-            const entrypoint = feedEntrypoint(feed);
-            entries.push(join(root, entrypoint.file));
+            const entrypoints = feedEntrypoints(feed);
+            for (const entrypoint of entrypoints) {
+                entries.push(join(root, entrypoint.file));
+            }
             return unpackFeed(root, feed);
         })
     );

--- a/test/__snapshots__/reader.test.js.snap
+++ b/test/__snapshots__/reader.test.js.snap
@@ -85,72 +85,6 @@ exports[`bundling dedupes common modules 2`] = `
 }
 `;
 
-exports[`bundling dedupes common modules 3`] = `
-"(function e(t, n, r) {
-  function s(o, u) {
-    if (!n[o]) {
-      if (!t[o]) {
-        var a = typeof require == \\"function\\" && require;
-        if (!u && a) return a(o, !0);
-        if (i) return i(o, !0);
-        var f = new Error(\\"Cannot find module '\\" + o + \\"'\\");
-        throw ((f.code = \\"MODULE_NOT_FOUND\\"), f);
-      }
-      var l = (n[o] = { exports: {} });
-      t[o][0].call(
-        l.exports,
-        function(e) {
-          var n = t[o][1][e];
-          return s(n ? n : e);
-        },
-        l,
-        l.exports,
-        e,
-        t,
-        n,
-        r
-      );
-    }
-    return n[o].exports;
-  }
-  var i = typeof require == \\"function\\" && require;
-  for (var o = 0; o < r.length; o++) s(r[o]);
-  return s;
-})(
-  {
-    1: [
-      function(require, module, exports) {
-        require(\\"./c\\");
-        spy(\\"b\\");
-      },
-      { \\"./c\\": 2 }
-    ],
-    2: [
-      function(require, module, exports) {
-        spy(\\"c\\");
-      },
-      {}
-    ],
-    3: [
-      function(require, module, exports) {
-        require(\\"./c\\");
-        spy(\\"a\\");
-      },
-      { \\"./c\\": 4 }
-    ],
-    4: [
-      function(require, module, exports) {
-        arguments[4][2][0].apply(exports, arguments);
-      },
-      { dup: 2 }
-    ]
-  },
-  {},
-  [3, 1]
-);
-"
-`;
-
 exports[`code reaches 3 entry points 1`] = `
 "(function e(t, n, r) {
   function s(o, u) {
@@ -478,6 +412,89 @@ exports[`minified code runs as expected 2`] = `
     ],
     Array [
       "b",
+    ],
+  ],
+}
+`;
+
+exports[`multiple entrypoints in same feed supported 1`] = `
+"(function e(t, n, r) {
+  function s(o, u) {
+    if (!n[o]) {
+      if (!t[o]) {
+        var a = typeof require == \\"function\\" && require;
+        if (!u && a) return a(o, !0);
+        if (i) return i(o, !0);
+        var f = new Error(\\"Cannot find module '\\" + o + \\"'\\");
+        throw ((f.code = \\"MODULE_NOT_FOUND\\"), f);
+      }
+      var l = (n[o] = { exports: {} });
+      t[o][0].call(
+        l.exports,
+        function(e) {
+          var n = t[o][1][e];
+          return s(n ? n : e);
+        },
+        l,
+        l.exports,
+        e,
+        t,
+        n,
+        r
+      );
+    }
+    return n[o].exports;
+  }
+  var i = typeof require == \\"function\\" && require;
+  for (var o = 0; o < r.length; o++) s(r[o]);
+  return s;
+})(
+  {
+    1: [
+      function(require, module, exports) {
+        spy(\\"c\\");
+      },
+      {}
+    ],
+    2: [
+      function(require, module, exports) {
+        spy(\\"d\\");
+      },
+      {}
+    ],
+    3: [
+      function(require, module, exports) {
+        spy(\\"a\\");
+      },
+      {}
+    ],
+    4: [
+      function(require, module, exports) {
+        spy(\\"b\\");
+      },
+      {}
+    ]
+  },
+  {},
+  [3, 4, 1, 2]
+);
+"
+`;
+
+exports[`multiple entrypoints in same feed supported 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "a",
+    ],
+    Array [
+      "b",
+    ],
+    Array [
+      "c",
+    ],
+    Array [
+      "d",
     ],
   ],
 }

--- a/test/feed-entrypoints.test.js
+++ b/test/feed-entrypoints.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const feedEntrypoint = require('../lib/feed-entrypoint');
+const feedEntrypoint = require('../lib/feed-entrypoints');
 
 test('determines entrypoint for simple feed', () => {
     const feed = [{ id: 1, file: '', source: '', deps: {}, entry: true }];
 
-    expect(feedEntrypoint(feed).id).toBe(1);
+    expect(feedEntrypoint(feed)[0].id).toBe(1);
 });
 
 test('determines entrypoint for feed', () => {
@@ -16,7 +16,7 @@ test('determines entrypoint for feed', () => {
         { id: 4, file: '', source: '', deps: {} },
     ];
 
-    expect(feedEntrypoint(feed).id).toBe(3);
+    expect(feedEntrypoint(feed)[0].id).toBe(3);
 });
 
 test('determines entrypoint for feed with falsey entrypoint', () => {
@@ -25,5 +25,17 @@ test('determines entrypoint for feed with falsey entrypoint', () => {
         { id: 2, file: '', source: '', deps: {}, entry: true },
     ];
 
-    expect(feedEntrypoint(feed).id).toBe(2);
+    expect(feedEntrypoint(feed)[0].id).toBe(2);
+});
+
+test('determines entrypoint for feed', () => {
+    const feed = [
+        { id: 1, file: '', source: '', deps: {} },
+        { id: 2, file: '', source: '', deps: {} },
+        { id: 3, file: '', source: '', deps: {}, entry: true },
+        { id: 4, file: '', source: '', deps: {}, entry: true },
+    ];
+
+    expect(feedEntrypoint(feed)[0].id).toBe(3);
+    expect(feedEntrypoint(feed)[1].id).toBe(4);
 });

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -316,7 +316,6 @@ test('bundling dedupes common modules', async () => {
     expect(clean(prettier.format(result))).toMatchSnapshot();
     expect(spy).toMatchSnapshot();
     expect(spy).toHaveBeenCalledTimes(4);
-    expect(clean(prettier.format(result))).toMatchSnapshot();
 });
 
 test('minified code runs as expected', async () => {
@@ -360,6 +359,54 @@ test('minified code runs as expected', async () => {
     );
     const spy = jest.fn();
     vm.runInNewContext(result, { spy });
+    expect(clean(prettier.format(result))).toMatchSnapshot();
+    expect(spy).toMatchSnapshot();
+    expect(spy).toHaveBeenCalledTimes(4);
+});
+
+test('multiple entrypoints in same feed supported', async () => {
+    const result = await bundleJS(
+        [
+            [
+                {
+                    entry: true,
+                    id: 'a',
+                    source: 'spy("a");',
+                    deps: {},
+                    file: './a.js',
+                },
+                {
+                    entry: true,
+                    id: 'b',
+                    source: 'spy("b");',
+                    deps: {},
+                    file: './c.js',
+                },
+            ],
+            [
+                {
+                    entry: true,
+                    id: 'c',
+                    source: 'spy("c");',
+                    deps: {},
+                    file: './b.js',
+                },
+                {
+                    entry: true,
+                    id: 'd',
+                    source: 'spy("d");',
+                    deps: {},
+                    file: './c.js',
+                },
+            ],
+        ],
+        {
+            directory: FOLDER,
+        }
+    );
+    const spy = jest.fn();
+    vm.runInNewContext(result, { spy });
+
     expect(clean(prettier.format(result))).toMatchSnapshot();
     expect(spy).toMatchSnapshot();
     expect(spy).toHaveBeenCalledTimes(4);


### PR DESCRIPTION
## JIRA Issue
[COREWEB-120](https://jira.finn.no/browse/COREWEB-120)
[COREWEB-181](https://jira.finn.no/browse/COREWEB-181)

## Status
**READY**

## Description
Changed to handle an array of feed items where `entrypoint: true` in reader instead of only ever returning a single feed item based on a return early approach.

## Todos
- [x] Tests

## Deploy Notes

## Related PRs
* None